### PR TITLE
fix: resolve getCurrentDiameter function error and update deprecated meta tag

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(npm run build:*)"
+    ],
+    "deny": []
+  }
+}

--- a/components/calculator/DiameterCalculation.tsx
+++ b/components/calculator/DiameterCalculation.tsx
@@ -195,6 +195,12 @@ export function DiameterCalculation({
   };
 
   const getCurrentCategoryValues = () => diameterCategories[currentDiameterCategory].values;
+  
+  const getCurrentDiameter = () => {
+    const values = diameterCategories[currentDiameterCategory].values;
+    const middleIndex = Math.floor(values.length / 2);
+    return values[middleIndex];
+  };
 
   const [selectedDiameterClass, setSelectedDiameterClass] = useState<keyof typeof iso26DiameterClasses>('mediumLarge');
 
@@ -542,39 +548,39 @@ export function DiameterCalculation({
               }}
               onMouseDown={(e) => {
                 e.preventDefault();
-                handleSlideStart(e.clientX);
+                handleCategorySlideStart(e.clientX);
               }}
               onMouseMove={(e) => {
                 if (isSliding) {
                   e.preventDefault();
-                  handleSlideMove(e.clientX);
+                  handleCategorySlideMove(e.clientX);
                 }
               }}
               onMouseUp={(e) => {
                 e.preventDefault();
-                handleSlideEnd();
+                handleCategorySlideEnd();
               }}
               onMouseLeave={(e) => {
                 if (isSliding) {
                   e.preventDefault();
-                  handleSlideEnd();
+                  handleCategorySlideEnd();
                 }
               }}
               onTouchStart={(e) => {
                 e.preventDefault();
                 const touch = e.touches[0];
-                handleSlideStart(touch.clientX);
+                handleCategorySlideStart(touch.clientX);
               }}
               onTouchMove={(e) => {
                 if (isSliding) {
                   e.preventDefault();
                   const touch = e.touches[0];
-                  handleSlideMove(touch.clientX);
+                  handleCategorySlideMove(touch.clientX);
                 }
               }}
               onTouchEnd={(e) => {
                 e.preventDefault();
-                handleSlideEnd();
+                handleCategorySlideEnd();
               }}
             />
             
@@ -606,7 +612,7 @@ export function DiameterCalculation({
             gap: '12px',
             marginTop: '20px'
           }}>
-            {diameterCategories[currentDiameterCategory].diameters.map((diameter) => (
+            {diameterCategories[currentDiameterCategory].values.map((diameter) => (
               <button
                 key={diameter}
                 onClick={() => addDiameterEntry(diameter)}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>Forestry Compliance Application</title>
     <meta name="description" content="Forestry Compliance Application for efficient timber volume calculations and LesEGAIS integration" />
     <meta name="theme-color" content="#10b981" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   </head>


### PR DESCRIPTION
- Fixed getCurrentDiameter function reference error by implementing missing function
- Updated function calls to use correct category slide handler names
- Fixed property name from 'diameters' to 'values' in button mapping
- Added modern mobile-web-app-capable meta tag alongside existing apple version
- All TypeScript errors resolved and build successful

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>