### PR TITLE
Add Storybook script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `storybook` development script for local Storybook server
- ensure `build-storybook` script remains available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6898471d0ad883279c4ed8bef08f660b