### PR TITLE
Add Storybook accessibility addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
   stories: ["../components/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["@storybook/addon-essentials"],
+  addons: ["@storybook/addon-essentials", "@storybook/addon-a11y"],
   framework: {
     name: "@storybook/react-vite",
     options: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@storybook/addon-a11y": "^7.6.7",
         "@storybook/addon-essentials": "^7.6.7",
         "@storybook/react-vite": "^7.6.7",
         "@types/node": "^20.11.3",
@@ -4698,6 +4699,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-7.6.7.tgz",
+      "integrity": "sha512-poT2oXIYDwLnhqn6g9ACTQ+7gi8QDHVlib4TQANdcozC/qYg+Bs6Pd99wT6rT4lrC/npVNTSKKwLw+3oXqlCxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/addon-highlight": "7.6.7",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-a11y/node_modules/@storybook/addon-highlight": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-7.6.7.tgz",
+      "integrity": "sha512-2F/tJdn45d4zrvf/cmE1vsczl99wK8+I+kkj0G7jLsrJR0w1zTgbgjy6T9j86HBTBvWcnysNFNIRWPAOh5Wdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addon-actions": {
       "version": "7.6.20",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-7.6.20.tgz",
@@ -8190,6 +8220,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-core": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "^7.6.7",
+    "@storybook/addon-essentials": "^7.6.7",
+    "@storybook/react-vite": "^7.6.7",
     "@types/node": "^20.11.3",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
@@ -64,11 +67,9 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "postcss": "^8.4.32",
+    "storybook": "^7.6.7",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.8",
-    "storybook": "^7.6.7",
-    "@storybook/react-vite": "^7.6.7",
-    "@storybook/addon-essentials": "^7.6.7"
+    "vite": "^5.0.8"
   }
 }


### PR DESCRIPTION
## Summary
- add accessibility addon to Storybook configuration
- include @storybook/addon-a11y as a dev dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_689847210af48327b6dbdb9de95b6046