### PR TITLE
chore: externalize radix checkbox import

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      external: ['sonner@2.0.3', 'next-themes@0.4.6'],
+      external: ['sonner@2.0.3', 'next-themes@0.4.6', '@radix-ui/react-checkbox@1.1.4'],
     },
   },
   define: {


### PR DESCRIPTION
## Summary
- add @radix-ui/react-checkbox@1.1.4 to Vite's rollup external list to avoid unresolved imports

## Testing
- `npm run build`
- `npm run build-storybook` *(fails: Rollup failed to resolve import "next-themes@0.4.6" from "./components/ui/sonner.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_689856963aac8327a33f8600d19b1014